### PR TITLE
feat: clean up docs, deps, and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Fastify OpenAPI Autoload Documentation
+# Fastify OpenAPI Autoload
 
-The `fastify-openapi-autoload` plugin is a tool for building API servers with Fastify, leveraging OpenAPI specifications. It integrates [`fastify-openapi-glue`](https://github.com/seriousme/fastify-openapi-glue) for handling OpenAPI specs and [`@fastify/autoload`](https://github.com/fastify/fastify-autoload) for auto-loading route handlers, streamlining the API setup process.
+The `fastify-openapi-autoload` plugin is a tool for building API servers with Fastify, leveraging OpenAPI specifications. It integrates [`fastify-openapi-glue`](https://github.com/seriousme/fastify-openapi-glue) for handling OpenAPI specs and [`@fastify/autoload`](https://github.com/fastify/fastify-autoload) for auto-loading route handlers.
 
 ## Features
 

--- a/example/README.md
+++ b/example/README.md
@@ -35,7 +35,17 @@ http GET :3000/foo
     mkcert "autotelic.localhost"
     ```
 
-4. Ensure the certificate filenames match those in `./example/jwt/index.js`.
+4. Ensure the certificate filenames match those in `./example/jwt/index.js`:
+
+    ```js
+    export const options = {
+      https: {
+        key: readFileSync(join('local-certs', 'autotelic.localhost-key.pem')),
+        cert: readFileSync(join('local-certs', 'autotelic.localhost.pem'))
+      },
+      maxParamLength: 500
+    }
+    ```
 
 ### Starting the Example Server
 
@@ -47,7 +57,7 @@ cd ./example/jwt
 npm i && npm start
 ```
 
-Once the server is running, a request using HTTPie will print to the console. You can copy and use to test a protected route:
+Once the server is running, a request using HTTPie will print to the console. You can copy and use this to test a protected route:
 
 ```sh
 http https://autotelic.localhost:3000/foo 'Authorization:Bearer <JWT_TOKEN>'

--- a/example/jwt/index.js
+++ b/example/jwt/index.js
@@ -30,7 +30,7 @@ export default async function app (fastify, opts) {
   // register openapiAutoload:
   fastify.register(openapiAutoload, {
     handlersDir: join(fixturesDir, 'handlers'),
-    openapiOpts: { specification: join(fixturesDir, 'spec', 'test-spec.yaml') },
+    openapiOpts: { specification: join(fixturesDir, 'spec', 'openapi.yaml') },
     makeSecurityHandlers
   })
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   "homepage": "https://github.com/autotelic/fastify-openapi-autoload#readme",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",
-    "fastify-openapi-glue": "4.4.2",
+    "fast-jwt": "^4.0.0",
+    "fastify-openapi-glue": "^4.4.3",
     "fastify-plugin": "^4.5.1",
     "json-refs": "^3.0.15",
     "yamljs": "^0.3.0"
@@ -46,7 +47,6 @@
     "@typescript-eslint/parser": "^7.0.2",
     "eslint": "^8.56.0",
     "eslint-import-resolver-typescript": "^3.6.1",
-    "fast-jwt": "^3.3.2",
     "fastify": "^4.25.2",
     "jose": "^5.2.0",
     "nock": "^13.5.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   "homepage": "https://github.com/autotelic/fastify-openapi-autoload#readme",
   "dependencies": {
     "@fastify/autoload": "^5.8.0",
-    "fast-jwt": "^4.0.0",
     "fastify-openapi-glue": "^4.4.3",
     "fastify-plugin": "^4.5.1",
     "json-refs": "^3.0.15",
@@ -47,6 +46,7 @@
     "@typescript-eslint/parser": "^7.0.2",
     "eslint": "^8.56.0",
     "eslint-import-resolver-typescript": "^3.6.1",
+    "fast-jwt": "^4.0.0",
     "fastify": "^4.25.2",
     "jose": "^5.2.0",
     "nock": "^13.5.0",


### PR DESCRIPTION
# Summary

- update docs
- update `fast-jwt` and `openapi-glue` to latest
- fix spec file in jwt example

# Test Plan

- run tests and lint: `npm run validate`
- run both examples by following the instructions in `example/README.md`
- review docs for errors or omissions