### PR TITLE
Pass options through to autoload, makeOperationResolver and makeSecurityHandlers

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,8 @@ async function openapiAutoload (fastify, options = {}) {
       dir: handlersDir,
       maxDepth: 1,
       dirNameRoutePrefix: false,
-      encapsulate: false
+      encapsulate: false,
+      options
     })
 
     const openapiGlueOpts = {
@@ -36,11 +37,11 @@ async function openapiAutoload (fastify, options = {}) {
 
     // Factory/creator functions for security handlers & operation resolver
     if (makeSecurityHandlers) {
-      openapiGlueOpts.securityHandlers = makeSecurityHandlers(fastify)
+      openapiGlueOpts.securityHandlers = makeSecurityHandlers(fastify, options)
     }
 
     if (makeOperationResolver) {
-      openapiGlueOpts.operationResolver = makeOperationResolver(fastify)
+      openapiGlueOpts.operationResolver = makeOperationResolver(fastify, options)
     }
 
     // Resolve multi-file OpenAPI specification

--- a/test/fixtures/handlers/getBar/index.js
+++ b/test/fixtures/handlers/getBar/index.js
@@ -1,6 +1,6 @@
-export default async (fastify, { operationId }) => {
+export default async (fastify, { operationId, foo }) => {
   fastify.decorate(operationId, async (_req, reply) => {
-    reply.code(200).send('bar')
+    reply.code(200).send(foo)
   })
 }
 


### PR DESCRIPTION
Needed to be able to pass through host constraints. I updated the tests to show that they are being passed through and don't break anything.